### PR TITLE
fix: properly handle multiple tool calls

### DIFF
--- a/examples/toolbox-dummy-gemini.php
+++ b/examples/toolbox-dummy-gemini.php
@@ -5,11 +5,13 @@ use PhpLlm\LlmChain\Bridge\Google\PlatformFactory;
 use PhpLlm\LlmChain\Chain;
 use PhpLlm\LlmChain\Chain\ToolBox\Attribute\AsTool;
 use PhpLlm\LlmChain\Chain\ToolBox\ChainProcessor;
+use PhpLlm\LlmChain\Chain\ToolBox\Tool\Clock;
 use PhpLlm\LlmChain\Chain\ToolBox\ToolAnalyzer;
 use PhpLlm\LlmChain\Chain\ToolBox\ToolBox;
 use PhpLlm\LlmChain\Model\Message\Message;
 use PhpLlm\LlmChain\Model\Message\MessageBag;
 use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\Clock\Clock as SymfonyClock;
 
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');
@@ -35,12 +37,13 @@ class Dummy
 $platform = PlatformFactory::create($_ENV['GOOGLE_API_KEY']);
 $llm = new GoogleModel(GoogleModel::GEMINI_2_FLASH);
 $dummy = new Dummy();
+$clock = new Clock(new SymfonyClock());
 
-$toolBox = new ToolBox(new ToolAnalyzer(), [$dummy]);
+$toolBox = new ToolBox(new ToolAnalyzer(), [$dummy, $clock]);
 $processor = new ChainProcessor($toolBox);
 $chain = new Chain($platform, $llm, [$processor], [$processor]);
 
-$messages = new MessageBag(Message::ofUser('What is the weather like in Los Angeles, and how about Amsterdam? Is this likely correct?'));
+$messages = new MessageBag(Message::ofUser('What date and time is it? And what is the weather like in Los Angeles, and how about Amsterdam? Is this likely correct?'));
 $response = $chain->call($messages);
 
 echo $response->getContent().PHP_EOL;

--- a/examples/toolbox-dummy-gemini.php
+++ b/examples/toolbox-dummy-gemini.php
@@ -10,8 +10,8 @@ use PhpLlm\LlmChain\Chain\ToolBox\ToolAnalyzer;
 use PhpLlm\LlmChain\Chain\ToolBox\ToolBox;
 use PhpLlm\LlmChain\Model\Message\Message;
 use PhpLlm\LlmChain\Model\Message\MessageBag;
-use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\Clock\Clock as SymfonyClock;
+use Symfony\Component\Dotenv\Dotenv;
 
 require_once dirname(__DIR__).'/vendor/autoload.php';
 (new Dotenv())->loadEnv(dirname(__DIR__).'/.env');

--- a/src/Bridge/Google/GoogleRequestBodyProducer.php
+++ b/src/Bridge/Google/GoogleRequestBodyProducer.php
@@ -10,6 +10,7 @@ use PhpLlm\LlmChain\Model\Message\Content\Image;
 use PhpLlm\LlmChain\Model\Message\Content\Text;
 use PhpLlm\LlmChain\Model\Message\MessageBagInterface;
 use PhpLlm\LlmChain\Model\Message\MessageVisitor;
+use PhpLlm\LlmChain\Model\Message\Role;
 use PhpLlm\LlmChain\Model\Message\SystemMessage;
 use PhpLlm\LlmChain\Model\Message\ToolCallMessage;
 use PhpLlm\LlmChain\Model\Message\UserMessage;
@@ -91,7 +92,7 @@ final class GoogleRequestBodyProducer implements RequestBodyProducer, MessageVis
     {
         $parts = [];
         foreach ($message->content as $content) {
-            $parts[] = [...$content->accept($this)];
+            $parts[] = $content->accept($this);
         }
 
         return [
@@ -112,7 +113,7 @@ final class GoogleRequestBodyProducer implements RequestBodyProducer, MessageVis
                     fn (ToolCall $toolCall) => [
                         'functionCall' => [
                             'name' => $toolCall->name,
-                            'args' => $toolCall->arguments,
+                            'args' => (object) $toolCall->arguments,
                         ],
                     ],
                     $message->toolCalls
@@ -169,6 +170,7 @@ final class GoogleRequestBodyProducer implements RequestBodyProducer, MessageVis
     public function visitToolCallMessage(ToolCallMessage $message): array
     {
         return [
+            'role' => Role::User,
             'parts' => [
                 [
                     'functionResponse' => [

--- a/src/Bridge/Google/ModelHandler.php
+++ b/src/Bridge/Google/ModelHandler.php
@@ -80,17 +80,22 @@ final readonly class ModelHandler implements ModelClient, ResponseConverter
 
         $candidate = $data['candidates'][0];
 
-        // Handle function call response
         if (isset($candidate['content']['parts'][0]['functionCall'])) {
-            $functionCall = $candidate['content']['parts'][0]['functionCall'];
+            $toolCalls = [];
 
-            $toolCall = new ToolCall(
-                id: uniqid('google-'), // Google doesn't provide IDs
-                name: $functionCall['name'],
-                arguments: (array) $functionCall['args']
-            );
+            foreach ($candidate['content']['parts'] as $part) {
+                if (!isset($part['functionCall'])) {
+                    continue;
+                }
 
-            return new ToolCallResponse($toolCall);
+                $toolCalls[] = new ToolCall(
+                    id: uniqid('google-'),
+                    name: $part['functionCall']['name'],
+                    arguments: (array) $part['functionCall']['args']
+                );
+            }
+
+            return new ToolCallResponse(...$toolCalls);
         }
 
         // Regular text response


### PR DESCRIPTION
Current chain processor architecture doesn't allow us to format in a way Google ideally would like to see, not without introducing ugliness, but this does seem supported. Ideally tool call results are formatted as follows:
```json
    {
        "role": "user",
        "parts": [
            {
                "functionResponse": {
                    "name": "get_current_weather",
                    "response": {
                        "temperature": 30.5,
                        "unit": "C"
                    }
                }
            },
            {
                "functionResponse": {
                    "name": "get_current_weather",
                    "response": {
                        "temperature": 20,
                        "unit": "C"
                    }
                }
            }
        ]
    }
```
https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/function-calling